### PR TITLE
fix(#15): 모듈 제외 설정 및 컨테이너 파일 삭제

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,9 @@
 .gitignore
 
 # node_modules 제외 (각 컨테이너 내부에서 설치하므로)
+frontend/node_modules
+backend/node_modules
+# 추가 안전장치
 **/node_modules
 
 # 빌드 결과물 제외

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
-# 의존성 패키지 폴더
+# 의존성 패키지 폴더 (명시적 경로 - 우선 적용)
+frontend/node_modules
+backend/node_modules
+
+# 추가 안전장치 (다른 위치의 node_modules도 대비)
 **/node_modules
 
 # 빌드 결과물

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -7,7 +7,6 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
-node_modules
 dist
 dist-ssr
 *.local


### PR DESCRIPTION
vscode 컨테이너 오류 발생 이전 커밋으로 롤백 후 깃 이그노어 설정 완료

1. 00e50a9d0cf5ee654ae21553c3028c6949618d0e 시점으로 돌렸습니다.
2. node modules 제외 설정이 안되는 경우가 있어 이그노어 설정을 수정