### PR TITLE
feat(#18) 자소서 분석 백엔드 복원 및 dev 기반 재구현

### DIFF
--- a/backend/src/config/app.config.ts
+++ b/backend/src/config/app.config.ts
@@ -3,7 +3,7 @@
 
 export const appConfig = () => ({
   app: {
-    port: parseInt(process.env.PORT, 10) || 3000,
+    port: parseInt(process.env.PORT || '3000', 10),
     nodeEnv: process.env.NODE_ENV || 'development',
     corsOrigin: process.env.CORS_ORIGIN || 'http://localhost:5173',
   },

--- a/backend/src/config/database.config.ts
+++ b/backend/src/config/database.config.ts
@@ -5,7 +5,7 @@ export const databaseConfig = () => ({
   database: {
     type: process.env.DATABASE_TYPE || 'postgres',
     host: process.env.DATABASE_HOST || 'localhost',
-    port: parseInt(process.env.DATABASE_PORT, 10) || 5432,
+    port: parseInt(process.env.DATABASE_PORT || '5432' , 10),
     username: process.env.DATABASE_USERNAME || 'postgres',
     password: process.env.DATABASE_PASSWORD || 'password',
     database: process.env.DATABASE_NAME || 'jobcrush',
@@ -21,7 +21,7 @@ export const jwtConfig = () => ({
 
 export const appConfig = () => ({
   app: {
-    port: parseInt(process.env.PORT, 10) || 3000,
+    port: parseInt(process.env.PORT || '3000', 10),
     nodeEnv: process.env.NODE_ENV || 'development',
     corsOrigin: process.env.CORS_ORIGIN || 'http://localhost:5173',
   },

--- a/backend/src/features/analysis/analysis.controller.spec.ts
+++ b/backend/src/features/analysis/analysis.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AnalysisController } from './analysis.controller';
+
+describe('AnalysisController', () => {
+  let controller: AnalysisController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AnalysisController],
+    }).compile();
+
+    controller = module.get<AnalysisController>(AnalysisController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/features/analysis/analysis.controller.ts
+++ b/backend/src/features/analysis/analysis.controller.ts
@@ -1,17 +1,48 @@
-// 분석 컨트롤러
-// 분석 관련 API 엔드포인트를 정의합니다
 
-import { Controller, Get } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Body,
+  UploadedFile,
+  UseInterceptors,
+  BadRequestException,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
 import { AnalysisService } from './analysis.service';
+import { AnalyzeResumeDto } from './dto/analyze-resume.dto';
+import { Buffer } from 'buffer';
+
+export interface MulterFile {
+  fieldname: string;
+  originalname: string;
+  encoding: string;
+  mimetype: string;
+  size: number;
+  buffer: Buffer;
+}
 
 @Controller('analysis')
 export class AnalysisController {
   constructor(private readonly analysisService: AnalysisService) {}
 
-  // TODO: 분석 로직 구현
-  // @Get('trends')
-  // async getTrends() {
-  //   return this.analysisService.getTrends();
-  // }
-}
+  @Post('resume')
+  async analyzeResume(@Body() dto: AnalyzeResumeDto) {
+    return this.analysisService.analyzeWithGemini(
+      dto.resumeText,
+      dto.jobDescription,
+    );
+  }
 
+  @Post('resume/upload')
+  @UseInterceptors(FileInterceptor('file'))
+  async analyzeResumePdf(
+    @UploadedFile() file: MulterFile,
+    @Body('jobDescription') jobDescription: string,
+  ) {
+    if (!file || !file.buffer) {
+      throw new BadRequestException('파일이 업로드되지 않았습니다.');
+    }
+    const text = await this.analysisService.extractTextFromPdf(file.buffer);
+    return this.analysisService.analyzeWithGemini(text, jobDescription);
+  }
+}

--- a/backend/src/features/analysis/analysis.module.ts
+++ b/backend/src/features/analysis/analysis.module.ts
@@ -1,14 +1,9 @@
-// 분석 모듈
-// 채용 정보 분석 기능을 담당합니다
-
 import { Module } from '@nestjs/common';
 import { AnalysisController } from './analysis.controller';
 import { AnalysisService } from './analysis.service';
 
 @Module({
   controllers: [AnalysisController],
-  providers: [AnalysisService],
-  exports: [AnalysisService],
+  providers: [AnalysisService]
 })
 export class AnalysisModule {}
-

--- a/backend/src/features/analysis/analysis.service.spec.ts
+++ b/backend/src/features/analysis/analysis.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AnalysisService } from './analysis.service';
+
+describe('AnalysisService', () => {
+  let service: AnalysisService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AnalysisService],
+    }).compile();
+
+    service = module.get<AnalysisService>(AnalysisService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/features/analysis/analysis.service.ts
+++ b/backend/src/features/analysis/analysis.service.ts
@@ -1,13 +1,97 @@
-// 분석 서비스
-// 데이터 분석 비즈니스 로직을 처리합니다
-
 import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { GoogleGenerativeAI, GenerationConfig } from '@google/generative-ai';
+
+// [핵심] require를 사용해서 강제로 불러옵니다.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const pdfParse = require('pdf-parse');
 
 @Injectable()
 export class AnalysisService {
-  // TODO: 분석 로직 구현
-  // async analyzeSalaryTrends() {
-  //   // 분석 로직
-  // }
-}
+  private genAI: GoogleGenerativeAI;
 
+  constructor(private readonly configService: ConfigService) {
+    const apiKey = this.configService.get<string>('GOOGLE_API_KEY');
+    if (!apiKey) throw new Error('Key Error');
+    this.genAI = new GoogleGenerativeAI(apiKey);
+  }
+
+  async extractTextFromPdf(buffer: Buffer): Promise<string> {
+    try {
+      // require로 불러왔으므로 이제 함수로 실행됩니다.
+      const data = await pdfParse(buffer);
+      return data.text;
+    } catch (error) {
+      console.error('PDF Error:', error);
+      throw new Error('PDF 파싱 실패');
+    }
+  }
+
+  async analyzeWithGemini(resumeText: string, jobDescription: string) {
+    const model = this.genAI.getGenerativeModel({ model: 'gemini-2.5-flash' });
+    const prompt = this.createAnalysisPrompt(resumeText, jobDescription);
+    
+    try {
+      const result = await model.generateContent({
+        contents: [{ role: 'user', parts: [{ text: prompt }] }],
+      });
+      const responseText = result.response.text();
+      // 마크다운 제거
+      const cleanedText = responseText.replace(/```json|```/g, '').trim();
+      return JSON.parse(cleanedText);
+    } catch (error) {
+      console.error('Gemini Error:', error);
+      throw new Error('AI 분석 실패');
+    }
+  }
+  private createAnalysisPrompt(resume: string, jd: string): string {
+      return `
+      당신은 수석 채용 담당자이자 전문 커리어 코치입니다.
+      제시된 [채용 공고]를 기준으로 [자소서 원문]을 분석하고,
+      제안서 요구사항인 [맞춤법 교정], [문맥 흐름], [직무 키워드 적합성], [강점 및 약점], [예상 면접 질문]을
+      반드시 JSON 형식으로 반환해야 합니다.
+
+      [채용 공고]
+      ${jd}
+
+      [자소서 원문]
+      ${resume}
+
+      [요구사항 및 JSON 출력 형식]
+      {
+        "overallAssessment": "자소서에 대한 전반적인 총평 (예: '직무 이해도는 높으나, 구체적인 성과가 부족합니다.')",
+        "proofreading": [
+          {
+            "original": "잘못된 원문 부분",
+            "corrected": "수정 제안",
+            "advice": "수정 이유 (예: '맞춤법 오류')"
+          }
+        ],
+        "keywordAnalysis": {
+          "requiredKeywords": ["채용 공고의 핵심 키워드 1", "키워드 2"],
+          "matchedKeywords": ["자소서에서 발견된 일치 키워드 1"],
+          "missingKeywords": ["자소서에 누락되었지만 중요한 키워드 1"],
+          "advice": "키워드 적합성 및 보완점에 대한 조언"
+        },
+        "strengths": [
+          "자소서에 드러난 강점 1 (직무 연관성)",
+          "강점 2"
+        ],
+        "weaknesses": [
+          "자소서에 드러난 약점 또는 보완점 1",
+          "약점 2"
+        ],
+        "interviewQuestions": [
+          {
+            "question": "자소서 내용 기반의 예상 면접 질문 1 (예: '00 프로젝트 경험에 대해 더 자세히 설명해주세요.')",
+            "intention": "이 질문의 의도 (예: '문제 해결 능력을 확인하기 위함')"
+          },
+          {
+            "question": "자소서와 채용 공고를 연결한 압박 질문 1",
+            "intention": "직무 적합성을 재확인하기 위함"
+          }
+        ]
+      }
+    `;
+  }
+}

--- a/backend/src/features/analysis/dto/analyze-resume.dto.ts
+++ b/backend/src/features/analysis/dto/analyze-resume.dto.ts
@@ -1,0 +1,13 @@
+import { IsNotEmpty, IsString, MinLength } from 'class-validator';
+
+export class AnalyzeResumeDto {
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(100)
+  resumeText: string; // 자소서 원문
+
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(50)
+  jobDescription: string; // 채용 공고 (JD) 내용
+}


### PR DESCRIPTION
## 📄 작업 개요
dev 최신 내용 기반으로 자소서 분석 백엔드 기능을 완전히 복원하고 재구현한 PR입니다.

## 🔧 주요 변경 사항
- analysis.controller / analysis.service / analysis.module 복원 및 리팩토링
- Multer 기반 PDF 업로드 엔드포인트 재구현
- pdf-parse 기반 자소서 텍스트 추출 기능 정상화
- Google Gemini API 연동 복구 및 프롬프트/응답 파싱 로직 개선
- dto 구조 재정리 (`analyze-resume.dto.ts`) 복원
- app.module.ts 에 AnalysisModule 단일 등록 (중복 제거)
- config(app.config.ts / database.config.ts)에서 타입 오류(TS2345) 수정

## 🐳 Docker 환경 테스트
- backend 단독 Docker build 성공
- docker compose 환경에서 Nest 서버 정상 기동 확인
- Multer 파일 업로드 정상 동작 확인
- PDF 분석 + Gemini 응답 정상 수신 확인

## 🧪 Postman 테스트 결과
- `POST /analysis/text` → 정상 응답
- `POST /analysis/upload` → PDF 업로드 및 분석 결과 정상 반환
<img width="1139" height="889" alt="image" src="https://github.com/user-attachments/assets/072c4596-05ca-4a86-a77d-16d6fa85746d" />


## 📌 기타
- 이전 브랜치 히스토리 정리 (force-with-lease 사용해 최신 dev 기준으로 재정비)
- dev와 충돌 없음 (Able to merge)
