### PR TITLE
feat(#23) : 면접프론트 UI 및 분석처리

### DIFF
--- a/docs/interview-client-overview.md
+++ b/docs/interview-client-overview.md
@@ -1,0 +1,146 @@
+## 면접 클라이언트 개요 (2025-12-03)
+
+### 1. 현재 프론트엔드 구현 현황
+
+#### 1-1. 폴더 구조
+
+```
+frontend/src/
+├── pages/interviews/
+│   ├── InterviewSetupPage.tsx      # 기업/직무 입력 및 데모 세션 시작
+│   ├── InterviewSessionPage.tsx    # 실시간 면접 진행 화면
+│   └── InterviewResultPage.tsx     # 모의 평가 리포트
+└── features/interviews/
+    ├── components/                 # 재사용 가능한 UI 블록
+    │   ├── VideoCapture.tsx        # 카메라 스트림 표시
+    │   ├── AudioIndicator.tsx      # 마이크 레벨 게이지
+    │   ├── QuestionDisplay.tsx     # 질문 카드
+    │   ├── SessionControls.tsx     # 시작/일시정지/종료 버튼
+    │   ├── RealtimeFeedback.tsx    # 실시간 피드백 래퍼
+    │   ├── GazeIndicator.tsx       # 시선 집중도
+    │   ├── ExpressionIndicator.tsx # 표정/헤드포즈
+    │   ├── AudioFeedback.tsx       # 피치·에너지·WPM·Jitter
+    │   ├── EvaluationChart.tsx     # 종합 점수 차트
+    │   ├── TimelineView.tsx        # 질문별 타임라인
+    │   └── StrengthsWeaknesses.tsx # 강점/약점/제안 정리
+    ├── hooks/
+    │   ├── useMediaStream.ts       # getUserMedia 래퍼
+    │   ├── useMediaPipe.ts         # MediaPipe FaceMesh 분석
+    │   ├── useAudioAnalysis.ts     # Web Audio API + pitchfinder
+    │   ├── useRealtimeAnalysis.ts  # 분석 데이터 패키징/전송
+    │   ├── useInterviewSocket.ts   # Socket.IO 연결/이벤트
+    │   └── useInterviewSession.ts  # REST 세션 상태 관리
+    ├── services/
+    │   ├── interview.service.ts    # REST (세션 생성/조회/평가)
+    │   └── socket.service.ts       # Socket.IO 클라이언트
+    └── types/
+        ├── interview.types.ts      # 세션/질문/평가 모델
+        ├── analysis.types.ts       # 얼굴·음성 분석 페이로드
+        └── socket.types.ts         # WS 이벤트 정의
+```
+
+#### 1-2. 사용 라이브러리
+
+- React 19 + Vite + Tailwind (UI)
+- `socket.io-client` (WebSocket)
+- `@mediapipe/face_mesh`, `@tensorflow-models/face-landmarks-detection`, `kalidokit` (시선·표정 추정)
+- Web Audio API + `pitchfinder` (피치/에너지)
+- React Router / Axios 등 공통 스택
+
+#### 1-3. 구현 기능
+
+- **라우팅**: `/interviews/setup`, `/interviews/session/:sessionId`, `/interviews/result/:sessionId` (DefaultLayout 사용, 세션 페이지는 사이드바 숨김)
+- **카메라/마이크 제어**: `useMediaStream` → `VideoCapture`, `AudioIndicator`
+- **실시간 분석(프론트)**: MediaPipe FaceMesh + Web Audio API로 시선/표정/헤드포즈/피치/에너지를 측정해 UI에 표시
+- **WebSocket 뼈대**: `socket.service.ts`와 `useInterviewSocket`이 질문/피드백 이벤트를 구독하고, `useRealtimeAnalysis`가 실시간 데이터를 emit하도록 설계
+- **면접 결과 UI**: 차트/타임라인/강점·약점 카드로 Mock 데이터를 시각화
+- **CTA 연동**: 분석 결과 페이지 및 사이드바에서 면접 페이지로 자연스럽게 연결
+
+> ⚠️ 설치 시 `@mediapipe/face_mesh`, `@tensorflow-models/face-landmarks-detection`, `kalidokit`, `pitchfinder`, `socket.io-client`를 함께 설치해야 하며, npm 레지스트리에 존재하는 버전으로 지정해야 합니다. (`@tensorflow-models/face-landmarks-detection`은 현재 `^1.0.4`를 권장)
+
+---
+
+### 2. Nest.js 기반 백엔드 계획
+
+#### 2-1. API & 소켓 책임
+
+| 역할                 | 상세                                                                                                                                                                                                   |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 세션 REST API        | `POST /interviews/sessions` (세션 생성), `GET /interviews/sessions/:id`, `GET /interviews/sessions/:id/evaluation`                                                                                     |
+| Socket.IO 게이트웨이 | 네임스페이스 `/ws/interviews`에서 <br/>`interview:question`, `interview:feedback`, `interview:completed` 이벤트 송신 및 <br/>`interview:audio`, `interview:analysis`, `interview:answer_complete` 수신 |
+| 인증                 | Front → Socket 연결 시 토큰 전달 후 게이트웨이에서 검증 (예: JWT)                                                                                                                                      |
+| 데이터 저장          | PostgreSQL/Prisma(TypeORM)로 세션, 질문, 답변, 분석 프레임, 평가 결과 저장                                                                                                                             |
+
+> **LLM/STT/TTS도 Nest.js 서비스에서 처리**
+>
+> - OpenAI SDK(또는 LangChain.js)를 Nest Provider로 등록하여 질문/피드백 생성
+> - Whisper API로 STT 호출 후 답변 텍스트 저장
+> - 필요 시 에이전트 패턴도 Node 진영에서 구현 가능
+
+#### 2-2. 데이터 흐름
+
+1. 프론트: 카메라/마이크 스트림 수집 → 간단한 로컬 분석 → `RealtimeAnalysisPayload` emit
+2. Nest 소켓 게이트웨이: payload 수신 → STT/LLM 호출에 참고 → 질문/피드백 생성 후 프론트로 push
+3. Nest REST API: 세션 생성·조회·평가 저장, 클라이언트 결과 페이지에서 조회
+4. 프론트: 서버에서 온 질문/피드백/평가 데이터를 UI에 반영
+
+#### 2-3. 백엔드 Checklist
+
+1. **엔티티/스키마**: `interview_sessions`, `interview_questions`, `interview_answers`, `analysis_frames`, `interview_evaluations`
+2. **Auth & Session Guard**: JWT/쿠키 기반 인증 후 소켓 연결 시 토큰 검증
+3. **파일/스트림 처리**: 오디오 청크 포맷 정의, Whisper API 호출 파이프라인 마련
+4. **큐/캐시**: Redis로 실시간 분석 값 캐싱 및 세션 상태 관리
+5. **모니터링**: WebSocket 연결 수, LLM/Whisper 호출 지연, 에러 로깅
+
+---
+
+### 3. Python/OpenCV 확장 시나리오 (별도 계획)
+
+| 구분           | 현재 (브라우저+Nest)            | 확장 (Python/OpenCV)                      |
+| -------------- | ------------------------------- | ----------------------------------------- |
+| 얼굴/표정 인식 | MediaPipe FaceMesh + TF.js      | OpenCV DNN + MediaPipe Python             |
+| 음성 분석      | Web Audio API + pitchfinder     | librosa/PyTorch 기반                      |
+| LLM/에이전트   | Nest.js 서비스에서 OpenAI 호출  | Python LangChain/에이전트 파이프라인      |
+| 장점           | 즉시 피드백, 서버 부하 적음     | 정밀도/일관성 ↑, ML 생태계 활용           |
+| 단점           | 디바이스 성능 의존, 정확도 한계 | 인프라/비용 증가, 네트워크 지연 고려 필요 |
+
+#### 3-1. 확장 전략
+
+1. 브라우저에서 수집한 원시 스트림을 WebRTC/Socket/WebTransport로 Python 서비스에 전송
+2. Python(OpenCV·MediaPipe·PyTorch)이 고정밀 분석 수행
+3. Nest.js는 게이트웨이 역할로 남아 Python 결과를 받아 WebSocket/REST로 전달
+4. 브라우저 분석 로직은 Feature Flag로 유지해 장애 시 기본 피드백 제공
+
+#### 3-2. Python 서비스 구성 예시
+
+| 모듈    | 기술                                     | 설명                                         |
+| ------- | ---------------------------------------- | -------------------------------------------- |
+| Vision  | OpenCV + MediaPipe Python                | 시선, 표정, 자세, 감정 분석 (고정밀)         |
+| Audio   | librosa, pyAudioAnalysis                 | 피치, 에너지, jitter, 말하기 속도, 휴지 분석 |
+| LLM     | GPT-4o / HuggingFace / LangChain         | 질문 생성, 꼬리 질문, 평가 멘트              |
+| STT/TTS | Whisper API, Google Speech-to-Text / TTS | 음성 인/아웃                                 |
+
+> 현재 버전은 Nest.js 단독 백엔드를 기본 전제로 하며, Python/OpenCV는 **완전 별도 확장 시나리오**입니다.
+
+---
+
+### 4. 향후 작업 항목 요약
+
+1. **백엔드**
+   - Nest.js에 인터뷰 모듈 추가 (REST + Socket 게이트웨이)
+   - Prisma/TypeORM으로 DB 스키마 구성
+   - LLM/STT/TTS Provider 작성 및 서비스 레이어 연동
+2. **프론트-백엔드 연동**
+   - `useInterviewSocket`에 실제 WS URL/토큰 연동
+   - `interviewService` REST 호출 연결 및 로딩/에러 핸들링
+   - 서버 피드백(점수/멘션)을 RealtimeFeedback/Evaluation UI에 주입
+3. **배포/운영**
+   - HTTPS(카메라 권한) 및 CORS 설정
+   - 환경 변수 템플릿 (`VITE_SOCKET_URL`, API 키) 업데이트
+   - npm 패키지 버전 고정 및 Docker 캐시 전략
+4. **(옵션) Python/OpenCV 확장 준비**
+   - 스트림 전송 포맷 정의, gRPC/WebRTC 브릿지 설계
+   - OpenCV/MediaPipe Python 파이프라인 프로토타입
+   - Nest ↔ Python 간 장애 대응/재전송 전략 마련
+
+이 문서를 기준으로 프론트 현황과 Nest.js 백엔드 요구사항을 공유하고, 필요 시 Python/OpenCV 확장은 별도 단계로 진행하면 됩니다. 문의 사항이 있으면 알려주세요!

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,14 +10,19 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@mediapipe/face_mesh": "^0.4.1633559619",
+    "@tensorflow-models/face-landmarks-detection": "^1.0.6",
     "@heroicons/react": "^2.2.0",
     "axios": "^1.7.9",
     "flowbite": "^3.1.2",
     "flowbite-react": "^0.12.10",
+    "kalidokit": "^1.1.0",
+    "pitchfinder": "^2.3.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-icons": "^5.5.0",
-    "react-router-dom": "^7.9.5"
+    "react-router-dom": "^7.9.5",
+    "socket.io-client": "^4.8.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",

--- a/frontend/src/components/layout/DefaultLayout.tsx
+++ b/frontend/src/components/layout/DefaultLayout.tsx
@@ -12,8 +12,14 @@ const DefaultLayout = ({ children }: { children: React.ReactNode }) => {
   const isExcludedRoute = excludedRoutes.includes(location.pathname);
 
   // 2. [추가 코드] "사이드바만" 숨길 경로들 정의
-  const noSidebarRoutes = ["/analysis", "/analysis/result"];
-  const isSidebarHidden = noSidebarRoutes.includes(location.pathname);
+  const noSidebarRoutes = [
+    "/analysis",
+    "/analysis/result",
+    "/interviews/setup",
+    "/interviews/session",
+    "/interviews/result",
+  ];
+  const isSidebarHidden = noSidebarRoutes.some((route) => location.pathname.startsWith(route));
 
   // 사이드바를 보여줄지 최종 결정 (전체 제외 경로가 아니고 && 사이드바 숨김 경로도 아닐 때)
   const showSidebar = !isExcludedRoute && !isSidebarHidden;

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -3,6 +3,7 @@ import { NavLink, useLocation } from "react-router-dom";
 import { GoHomeFill, GoGraph } from "react-icons/go";
 import { FaMicrophone } from "react-icons/fa";
 import { FaGear } from "react-icons/fa6";
+import { ROUTES } from "@/constants/routes";
 
 // --- 누락된 컴포넌트 임시 플레이스홀더 ---
 const SidebarLinkGroup = ({ children, activeCondition }: any) => {
@@ -102,9 +103,9 @@ const Sidebar = ({ sidebarOpen, setSidebarOpen }: SidebarProps) => {
               </li>
               <li>
                 <NavLink
-                  to="/calendar"
+                  to={ROUTES.INTERVIEWS.SETUP}
                   className={`group relative flex items-center gap-2.5 rounded-sm py-2 px-4 font-medium text-bodydark1 duration-300 ease-in-out hover:bg-graydark dark:hover:bg-meta-4 ${
-                    pathname.includes("calendar") &&
+                    pathname.startsWith("/interviews") &&
                     "bg-graydark dark:bg-meta-4"
                   }`}
                 >

--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -40,6 +40,13 @@ export const API_ENDPOINTS = {
     BY_ID: (id: string | number) => `/applications/${id}`,
     BY_USER: (userId: string) => `/applications/user/${userId}`,
   },
+
+  // 면접 관련
+  INTERVIEWS: {
+    SESSIONS: '/interviews/sessions',
+    SESSION_BY_ID: (sessionId: string) => `/interviews/sessions/${sessionId}`,
+    SESSION_EVALUATION: (sessionId: string) => `/interviews/sessions/${sessionId}/evaluation`,
+  },
   
   // 사용자 관련
   USERS: {

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -8,5 +8,10 @@ export const ROUTES = {
   JOB_DETAIL: (id: string | number) => `/jobs/${id}`,
   PROFILE: '/profile',
   APPLICATIONS: '/applications',
+  INTERVIEWS: {
+    SETUP: '/interviews/setup',
+    SESSION: (sessionId: string | number) => `/interviews/session/${sessionId}`,
+    RESULT: (sessionId: string | number) => `/interviews/result/${sessionId}`,
+  },
 } as const;
 

--- a/frontend/src/features/analysis/AnalysisResultPage.tsx
+++ b/frontend/src/features/analysis/AnalysisResultPage.tsx
@@ -9,6 +9,7 @@ import {
   FaCommentDots,
 } from "react-icons/fa";
 import { BiSolidQuoteLeft } from "react-icons/bi";
+import { ROUTES } from "@/constants/routes";
 
 // ----------------------------------------------------------------------
 // 1. 데이터 타입 정의 (백엔드 응답 스키마 예상)
@@ -243,7 +244,7 @@ const AnalysisResultPage = () => {
       {/* 3. 하단 플로팅 버튼 (모의 면접 시작) */}
       <div className="fixed bottom-10 left-0 right-0 flex justify-center z-50 pointer-events-none">
         <button
-          onClick={() => navigate("/interview/setup")} // 나중에 면접 설정 페이지로 이동
+          onClick={() => navigate(ROUTES.INTERVIEWS.SETUP)} // 나중에 면접 설정 페이지로 이동
           className="pointer-events-auto flex items-center gap-2 rounded-full bg-primary px-8 py-4 text-lg font-bold text-white shadow-2xl transition-all hover:-translate-y-1 hover:bg-opacity-90 hover:shadow-primary/50"
         >
           <FaCommentDots className="text-xl" />

--- a/frontend/src/features/interviews/components/AudioFeedback.tsx
+++ b/frontend/src/features/interviews/components/AudioFeedback.tsx
@@ -1,0 +1,29 @@
+import type { AudioAnalysisMetrics } from '../types/analysis.types';
+
+type AudioFeedbackProps = {
+  metrics: AudioAnalysisMetrics | null;
+};
+
+const StatItem = ({ label, value }: { label: string; value: string }) => (
+  <div className="flex flex-col rounded-lg border border-stroke p-3 text-center dark:border-strokedark">
+    <span className="text-xs text-gray-500">{label}</span>
+    <span className="text-lg font-bold text-black dark:text-white">{value}</span>
+  </div>
+);
+
+const AudioFeedback = ({ metrics }: AudioFeedbackProps) => {
+  return (
+    <div className="rounded-xl border border-stroke bg-white p-4 dark:border-strokedark dark:bg-boxdark">
+      <p className="text-xs font-semibold text-gray-500">음성 분석</p>
+      <div className="mt-3 grid grid-cols-2 gap-3">
+        <StatItem label="Pitch" value={metrics ? `${metrics.pitchHz} Hz` : '--'} />
+        <StatItem label="Energy" value={metrics ? metrics.energy.toString() : '--'} />
+        <StatItem label="WPM" value={metrics ? `${metrics.speechRateWpm}` : '--'} />
+        <StatItem label="Jitter" value={metrics ? `${metrics.jitter}` : '--'} />
+      </div>
+    </div>
+  );
+};
+
+export default AudioFeedback;
+

--- a/frontend/src/features/interviews/components/AudioIndicator.tsx
+++ b/frontend/src/features/interviews/components/AudioIndicator.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useRef, useState } from 'react';
+
+type AudioIndicatorProps = {
+  stream: MediaStream | null;
+};
+
+const AudioIndicator = ({ stream }: AudioIndicatorProps) => {
+  const [level, setLevel] = useState(0);
+  const animationRef = useRef<number>();
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const analyserRef = useRef<AnalyserNode | null>(null);
+
+  useEffect(() => {
+    if (!stream) {
+      setLevel(0);
+      return;
+    }
+
+    const audioContext = new AudioContext();
+    const source = audioContext.createMediaStreamSource(stream);
+    const analyser = audioContext.createAnalyser();
+    analyser.fftSize = 256;
+    source.connect(analyser);
+
+    audioContextRef.current = audioContext;
+    analyserRef.current = analyser;
+
+    const dataArray = new Uint8Array(analyser.frequencyBinCount);
+
+    const updateLevel = () => {
+      analyser.getByteTimeDomainData(dataArray);
+      let sum = 0;
+      for (let i = 0; i < dataArray.length; i += 1) {
+        const value = dataArray[i] - 128;
+        sum += value * value;
+      }
+      const rms = Math.sqrt(sum / dataArray.length) / 128;
+      setLevel(Math.min(1, rms * 2));
+      animationRef.current = requestAnimationFrame(updateLevel);
+    };
+
+    updateLevel();
+
+    return () => {
+      if (animationRef.current) cancelAnimationFrame(animationRef.current);
+      source.disconnect();
+      analyser.disconnect();
+      audioContext.close();
+    };
+  }, [stream]);
+
+  return (
+    <div className="rounded-xl border border-stroke p-4 dark:border-strokedark">
+      <p className="text-xs font-semibold text-gray-500">마이크 레벨</p>
+      <div className="mt-3 h-3 w-full rounded-full bg-gray-200 dark:bg-gray-700">
+        <div
+          className="h-full rounded-full bg-primary transition-[width]"
+          style={{ width: `${Math.round(level * 100)}%` }}
+        />
+      </div>
+      <p className="mt-2 text-xs text-gray-500">
+        {stream ? '마이크 입력이 감지되었습니다.' : '마이크 연결 대기 중'}
+      </p>
+    </div>
+  );
+};
+
+export default AudioIndicator;
+

--- a/frontend/src/features/interviews/components/EvaluationChart.tsx
+++ b/frontend/src/features/interviews/components/EvaluationChart.tsx
@@ -1,0 +1,54 @@
+import type { InterviewEvaluation, InterviewEvaluationMetric } from '../types/interview.types';
+
+type EvaluationChartProps = {
+  evaluation: Pick<
+    InterviewEvaluation,
+    'overallScore' | 'contentScore' | 'deliveryScore' | 'confidenceScore'
+  > & {
+    metrics?: InterviewEvaluationMetric[];
+  };
+};
+
+const MetricRow = ({ metric }: { metric: InterviewEvaluationMetric }) => (
+  <div className="flex items-center justify-between rounded-lg border border-stroke px-4 py-2 text-sm dark:border-strokedark">
+    <span>{metric.name}</span>
+    <span className="font-semibold text-black dark:text-white">{metric.score}점</span>
+  </div>
+);
+
+const EvaluationChart = ({ evaluation }: EvaluationChartProps) => {
+  const chartStyle = {
+    background: `conic-gradient(#3b82f6 ${evaluation.overallScore}%, #e5e7eb ${evaluation.overallScore}%)`,
+  };
+
+  const baseMetrics: InterviewEvaluationMetric[] = [
+    { name: '내용 전달', score: evaluation.contentScore },
+    { name: '커뮤니케이션', score: evaluation.deliveryScore },
+    { name: '자신감', score: evaluation.confidenceScore },
+  ];
+
+  const detailMetrics = evaluation.metrics ?? baseMetrics;
+
+  return (
+    <div className="grid gap-6 rounded-2xl border border-stroke bg-white p-6 shadow-sm dark:border-strokedark dark:bg-boxdark lg:grid-cols-2">
+      <div className="flex flex-col items-center justify-center gap-2">
+        <div className="relative h-48 w-48 rounded-full bg-gray-100 dark:bg-gray-800" style={chartStyle}>
+          <div className="absolute inset-6 rounded-full bg-white text-center dark:bg-boxdark">
+            <p className="mt-10 text-xs font-semibold uppercase text-gray-500">Overall</p>
+            <p className="text-4xl font-bold text-black dark:text-white">{evaluation.overallScore}</p>
+            <p className="text-xs text-gray-400">/ 100</p>
+          </div>
+        </div>
+        <p className="text-sm text-gray-500">AI가 평가한 종합 점수입니다.</p>
+      </div>
+      <div className="flex flex-col gap-3">
+        {detailMetrics.map((metric) => (
+          <MetricRow key={metric.name} metric={metric} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default EvaluationChart;
+

--- a/frontend/src/features/interviews/components/ExpressionIndicator.tsx
+++ b/frontend/src/features/interviews/components/ExpressionIndicator.tsx
@@ -1,0 +1,43 @@
+import type { FaceAnalysisMetrics } from '../types/analysis.types';
+
+type ExpressionIndicatorProps = {
+  metrics: FaceAnalysisMetrics | null;
+};
+
+const ExpressionIndicator = ({ metrics }: ExpressionIndicatorProps) => {
+  const expression = metrics?.expression;
+  const headPose = metrics?.headPose;
+
+  return (
+    <div className="rounded-xl border border-stroke bg-white p-4 dark:border-strokedark dark:bg-boxdark">
+      <p className="text-xs font-semibold text-gray-500">표정 & 헤드포즈</p>
+      <div className="mt-2 text-sm text-black dark:text-white">
+        <p className="font-semibold capitalize">
+          {expression ? `${expression.label}` : '분석 대기 중'}
+        </p>
+        <p className="text-xs text-gray-500">
+          Confidence: {expression ? `${Math.round(expression.confidence * 100)}%` : '--'}
+        </p>
+      </div>
+      {headPose && (
+        <div className="mt-3 grid grid-cols-3 gap-2 text-center text-xs text-gray-500 dark:text-gray-400">
+          <div>
+            <p className="font-semibold text-black dark:text-white">{headPose.pitch}°</p>
+            <p>Pitch</p>
+          </div>
+          <div>
+            <p className="font-semibold text-black dark:text-white">{headPose.yaw}°</p>
+            <p>Yaw</p>
+          </div>
+          <div>
+            <p className="font-semibold text-black dark:text-white">{headPose.roll}°</p>
+            <p>Roll</p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ExpressionIndicator;
+

--- a/frontend/src/features/interviews/components/GazeIndicator.tsx
+++ b/frontend/src/features/interviews/components/GazeIndicator.tsx
@@ -1,0 +1,28 @@
+import type { FaceAnalysisMetrics } from '../types/analysis.types';
+
+type GazeIndicatorProps = {
+  metrics: FaceAnalysisMetrics | null;
+};
+
+const GazeIndicator = ({ metrics }: GazeIndicatorProps) => {
+  const eyeContact = Math.round((metrics?.eyeContactScore ?? 0) * 100);
+
+  return (
+    <div className="rounded-xl border border-stroke bg-white p-4 dark:border-strokedark dark:bg-boxdark">
+      <p className="text-xs font-semibold text-gray-500">시선 집중도</p>
+      <div className="mt-3 h-2 w-full rounded-full bg-gray-200 dark:bg-gray-700">
+        <div
+          className="h-full rounded-full bg-primary transition-[width]"
+          style={{ width: `${Math.min(100, Math.max(0, eyeContact))}%` }}
+        />
+      </div>
+      <div className="mt-2 flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+        <span>Eye contact</span>
+        <span className="font-semibold text-black dark:text-white">{eyeContact}%</span>
+      </div>
+    </div>
+  );
+};
+
+export default GazeIndicator;
+

--- a/frontend/src/features/interviews/components/QuestionDisplay.tsx
+++ b/frontend/src/features/interviews/components/QuestionDisplay.tsx
@@ -1,0 +1,32 @@
+import type { InterviewQuestion } from '../types/interview.types';
+
+type QuestionDisplayProps = {
+  question?: Pick<InterviewQuestion, 'order' | 'text' | 'type'>;
+};
+
+const QuestionDisplay = ({ question }: QuestionDisplayProps) => {
+  if (!question) {
+    return (
+      <div className="rounded-xl border border-dashed border-stroke p-6 text-center text-sm text-gray-500 dark:border-strokedark dark:text-gray-400">
+        AI가 최신 질문을 준비 중입니다.
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-stroke bg-white p-6 shadow-sm dark:border-strokedark dark:bg-boxdark">
+      <div className="mb-3 flex items-center justify-between">
+        <span className="rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold capitalize text-primary">
+          {question.type}
+        </span>
+        <span className="text-xs font-medium text-gray-500">질문 {question.order}</span>
+      </div>
+      <p className="text-sm font-semibold leading-relaxed text-black dark:text-white">
+        {question.text}
+      </p>
+    </div>
+  );
+};
+
+export default QuestionDisplay;
+

--- a/frontend/src/features/interviews/components/RealtimeFeedback.tsx
+++ b/frontend/src/features/interviews/components/RealtimeFeedback.tsx
@@ -1,0 +1,28 @@
+import AudioFeedback from './AudioFeedback';
+import ExpressionIndicator from './ExpressionIndicator';
+import GazeIndicator from './GazeIndicator';
+import type { AudioAnalysisMetrics, FaceAnalysisMetrics } from '../types/analysis.types';
+
+type RealtimeFeedbackProps = {
+  faceMetrics: FaceAnalysisMetrics | null;
+  audioMetrics: AudioAnalysisMetrics | null;
+};
+
+const RealtimeFeedback = ({ faceMetrics, audioMetrics }: RealtimeFeedbackProps) => {
+  return (
+    <div className="rounded-2xl border border-stroke bg-white p-4 shadow-sm dark:border-strokedark dark:bg-boxdark">
+      <div className="mb-4">
+        <p className="text-xs font-semibold uppercase tracking-wide text-primary">Realtime insight</p>
+        <h3 className="text-lg font-semibold text-black dark:text-white">실시간 피드백</h3>
+      </div>
+      <div className="grid gap-3">
+        <GazeIndicator metrics={faceMetrics} />
+        <ExpressionIndicator metrics={faceMetrics} />
+        <AudioFeedback metrics={audioMetrics} />
+      </div>
+    </div>
+  );
+};
+
+export default RealtimeFeedback;
+

--- a/frontend/src/features/interviews/components/SessionControls.tsx
+++ b/frontend/src/features/interviews/components/SessionControls.tsx
@@ -1,0 +1,42 @@
+type SessionControlsProps = {
+  status: 'idle' | 'running' | 'paused';
+  onStart: () => void;
+  onPause: () => void;
+  onEnd: () => void;
+};
+
+const SessionControls = ({ status, onStart, onPause, onEnd }: SessionControlsProps) => {
+  const isRunning = status === 'running';
+  const isPaused = status === 'paused';
+
+  return (
+    <div className="flex flex-wrap gap-3">
+      <button
+        type="button"
+        onClick={onStart}
+        disabled={isRunning}
+        className="flex-1 rounded-lg bg-primary px-4 py-3 text-sm font-semibold text-white transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-primary/40"
+      >
+        {isPaused ? '면접 재개' : '면접 시작'}
+      </button>
+      <button
+        type="button"
+        onClick={onPause}
+        disabled={!isRunning}
+        className="flex-1 rounded-lg border border-stroke px-4 py-3 text-sm font-semibold text-black transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:text-gray-400 dark:border-strokedark dark:text-white"
+      >
+        일시정지
+      </button>
+      <button
+        type="button"
+        onClick={onEnd}
+        className="flex-1 rounded-lg border border-danger px-4 py-3 text-sm font-semibold text-danger transition hover:bg-danger/10"
+      >
+        종료
+      </button>
+    </div>
+  );
+};
+
+export default SessionControls;
+

--- a/frontend/src/features/interviews/components/StrengthsWeaknesses.tsx
+++ b/frontend/src/features/interviews/components/StrengthsWeaknesses.tsx
@@ -1,0 +1,38 @@
+type StrengthsWeaknessesProps = {
+  strengths: string[];
+  weaknesses: string[];
+  suggestions?: string[];
+};
+
+const ItemList = ({ title, color, items }: { title: string; color: string; items: string[] }) => (
+  <div className="rounded-2xl border border-stroke p-5 dark:border-strokedark">
+    <p className="mb-3 text-sm font-semibold" style={{ color }}>
+      {title}
+    </p>
+    <ul className="space-y-2 text-sm text-gray-600 dark:text-gray-300">
+      {items.map((item) => (
+        <li key={item} className="flex gap-2">
+          <span style={{ color }}>•</span>
+          <span>{item}</span>
+        </li>
+      ))}
+    </ul>
+  </div>
+);
+
+const StrengthsWeaknesses = ({ strengths, weaknesses, suggestions = [] }: StrengthsWeaknessesProps) => {
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <ItemList title="Strengths" color="#22c55e" items={strengths} />
+      <ItemList title="Improvements" color="#ef4444" items={weaknesses} />
+      {suggestions.length > 0 && (
+        <div className="md:col-span-2">
+          <ItemList title="Suggestions" color="#3b82f6" items={suggestions} />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default StrengthsWeaknesses;
+

--- a/frontend/src/features/interviews/components/TimelineView.tsx
+++ b/frontend/src/features/interviews/components/TimelineView.tsx
@@ -1,0 +1,36 @@
+type TimelineItem = {
+  id: string;
+  question: string;
+  score: number;
+  feedback: string;
+};
+
+type TimelineViewProps = {
+  items: TimelineItem[];
+};
+
+const TimelineView = ({ items }: TimelineViewProps) => {
+  return (
+    <div className="rounded-2xl border border-stroke bg-white p-6 shadow-sm dark:border-strokedark dark:bg-boxdark">
+      <h3 className="mb-4 text-lg font-semibold text-black dark:text-white">질문별 평가 타임라인</h3>
+      <ol className="relative border-l border-stroke pl-6 dark:border-strokedark">
+        {items.map((item, index) => (
+          <li key={item.id} className="mb-8 ml-4">
+            <div className="absolute -left-2 mt-1 flex h-4 w-4 items-center justify-center rounded-full border border-primary bg-white dark:bg-boxdark" />
+            <div className="rounded-lg border border-stroke p-4 dark:border-strokedark">
+              <div className="flex items-center justify-between text-xs text-gray-500">
+                <span>질문 {index + 1}</span>
+                <span className="font-semibold text-black dark:text-white">{item.score}점</span>
+              </div>
+              <p className="mt-2 text-sm font-semibold text-black dark:text-white">{item.question}</p>
+              <p className="mt-2 text-sm text-gray-500 dark:text-gray-300">{item.feedback}</p>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+};
+
+export default TimelineView;
+

--- a/frontend/src/features/interviews/components/VideoCapture.tsx
+++ b/frontend/src/features/interviews/components/VideoCapture.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from 'react';
+
+type VideoCaptureProps = {
+  stream: MediaStream | null;
+  mirror?: boolean;
+  placeholder?: React.ReactNode;
+};
+
+const VideoCapture = ({ stream, mirror = true, placeholder }: VideoCaptureProps) => {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+
+  useEffect(() => {
+    const videoElement = videoRef.current;
+    if (!videoElement) return;
+
+    if (stream) {
+      videoElement.srcObject = stream;
+      const playSafe = async () => {
+        try {
+          await videoElement.play();
+        } catch {
+          // autoplay might be blocked; ignore
+        }
+      };
+      playSafe();
+    } else {
+      videoElement.srcObject = null;
+    }
+  }, [stream]);
+
+  return (
+    <div className="relative aspect-video w-full overflow-hidden rounded-2xl border border-stroke bg-black dark:border-strokedark">
+      <video
+        ref={videoRef}
+        className={`h-full w-full object-cover ${mirror ? 'scale-x-[-1]' : ''}`}
+        muted
+        playsInline
+      />
+      {!stream && (
+        <div className="absolute inset-0 flex items-center justify-center text-sm text-white/60">
+          {placeholder ?? '카메라 접근 권한을 허용해주세요.'}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default VideoCapture;
+

--- a/frontend/src/features/interviews/hooks/useAudioAnalysis.ts
+++ b/frontend/src/features/interviews/hooks/useAudioAnalysis.ts
@@ -1,0 +1,66 @@
+import { useEffect, useRef, useState } from 'react';
+import { YIN } from 'pitchfinder';
+
+import type { AudioAnalysisMetrics } from '../types/analysis.types';
+
+export const useAudioAnalysis = (params: { stream: MediaStream | null; sessionId: string; questionId?: string }) => {
+  const { stream, sessionId, questionId } = params;
+  const [metrics, setMetrics] = useState<AudioAnalysisMetrics | null>(null);
+  const animationRef = useRef<number>();
+
+  useEffect(() => {
+    if (!stream) {
+      setMetrics(null);
+      return undefined;
+    }
+
+    const audioContext = new AudioContext();
+    const analyser = audioContext.createAnalyser();
+    analyser.fftSize = 2048;
+    const source = audioContext.createMediaStreamSource(stream);
+    source.connect(analyser);
+
+    const buffer = new Float32Array(analyser.fftSize);
+    const detectPitch = YIN({ sampleRate: audioContext.sampleRate });
+
+    let previousPitch = 0;
+
+    const updateMetrics = () => {
+      analyser.getFloatTimeDomainData(buffer);
+      const pitch = detectPitch(buffer, audioContext.sampleRate) ?? 0;
+
+      let sumSquares = 0;
+      for (let i = 0; i < buffer.length; i += 1) {
+        sumSquares += buffer[i] * buffer[i];
+      }
+      const energy = Math.sqrt(sumSquares / buffer.length);
+      const jitter = previousPitch ? Math.abs(pitch - previousPitch) / Math.max(previousPitch, 1) : 0;
+      const speechRateWpm = pitch > 0 ? 120 : 80;
+
+      setMetrics({
+        sessionId,
+        questionId,
+        timestamp: Date.now(),
+        pitchHz: Number(pitch.toFixed(2)),
+        energy: Number(energy.toFixed(3)),
+        speechRateWpm: Number(speechRateWpm.toFixed(1)),
+        jitter: Number(jitter.toFixed(3)),
+      });
+
+      previousPitch = pitch;
+      animationRef.current = requestAnimationFrame(updateMetrics);
+    };
+
+    updateMetrics();
+
+    return () => {
+      if (animationRef.current) cancelAnimationFrame(animationRef.current);
+      source.disconnect();
+      analyser.disconnect();
+      audioContext.close();
+    };
+  }, [questionId, sessionId, stream]);
+
+  return { metrics };
+};
+

--- a/frontend/src/features/interviews/hooks/useInterviewSession.ts
+++ b/frontend/src/features/interviews/hooks/useInterviewSession.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { interviewService } from '../services/interview.service';
+import type { CreateInterviewSessionPayload, InterviewSession } from '../types/interview.types';
+
+export const useInterviewSession = (sessionId?: string) => {
+  const [session, setSession] = useState<InterviewSession | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchSession = useCallback(async () => {
+    if (!sessionId) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await interviewService.getSession(sessionId);
+      setSession(response);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '세션 정보를 불러오지 못했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [sessionId]);
+
+  const createSession = useCallback(async (payload: CreateInterviewSessionPayload) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await interviewService.createSession(payload);
+      setSession(response);
+      return response;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '세션 생성에 실패했습니다.');
+      throw err;
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchSession();
+  }, [fetchSession]);
+
+  return {
+    session,
+    isLoading,
+    error,
+    refetch: fetchSession,
+    createSession,
+    setSession,
+  };
+};
+

--- a/frontend/src/features/interviews/hooks/useInterviewSocket.ts
+++ b/frontend/src/features/interviews/hooks/useInterviewSocket.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { interviewSocketClient } from '../services/socket.service';
+import type {
+  AudioStreamChunk,
+  InterviewFeedbackEvent,
+  InterviewQuestionEvent,
+  ServerToClientEvents,
+} from '../types/socket.types';
+import type { RealtimeAnalysisPayload } from '../types/analysis.types';
+
+const useSocketEvent = <K extends keyof ServerToClientEvents>(
+  event: K,
+  handler: ServerToClientEvents[K] | undefined,
+) => {
+  useEffect(() => {
+    if (!handler) return undefined;
+    const off = interviewSocketClient.on(event, handler);
+    return () => {
+      off?.();
+    };
+  }, [event, handler]);
+};
+
+export const useInterviewSocket = (params: { sessionId?: string; autoConnect?: boolean }) => {
+  const { sessionId, autoConnect = true } = params;
+  const [isConnected, setIsConnected] = useState(false);
+  const [currentQuestion, setCurrentQuestion] = useState<InterviewQuestionEvent['question']>();
+  const [latestFeedback, setLatestFeedback] = useState<InterviewFeedbackEvent | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!sessionId || !autoConnect) return undefined;
+    const socket = interviewSocketClient.connect();
+
+    const handleConnect = () => {
+      setIsConnected(true);
+      interviewSocketClient.joinSession(sessionId);
+    };
+
+    const handleDisconnect = () => {
+      setIsConnected(false);
+    };
+
+    socket.on('connect', handleConnect);
+    socket.on('disconnect', handleDisconnect);
+
+    return () => {
+      socket.off('connect', handleConnect);
+      socket.off('disconnect', handleDisconnect);
+      interviewSocketClient.leaveSession(sessionId);
+      interviewSocketClient.disconnect();
+    };
+  }, [autoConnect, sessionId]);
+
+  useSocketEvent('interview:question', (payload) => {
+    setCurrentQuestion(payload.question);
+  });
+
+  useSocketEvent('interview:feedback', (payload) => {
+    setLatestFeedback(payload);
+  });
+
+  useSocketEvent('interview:error', (payload) => {
+    setError(payload.message);
+  });
+
+  const sendAudioChunk = useCallback(
+    (chunk: AudioStreamChunk) => {
+      interviewSocketClient.sendAudioChunk(chunk);
+    },
+    [],
+  );
+
+  const sendRealtimeAnalysis = useCallback((payload: RealtimeAnalysisPayload) => {
+    interviewSocketClient.sendRealtimeAnalysis(payload);
+  }, []);
+
+  return {
+    isConnected,
+    currentQuestion,
+    latestFeedback,
+    error,
+    sendAudioChunk,
+    sendRealtimeAnalysis,
+  };
+};
+

--- a/frontend/src/features/interviews/hooks/useMediaPipe.ts
+++ b/frontend/src/features/interviews/hooks/useMediaPipe.ts
@@ -1,0 +1,131 @@
+import { useEffect, useRef, useState } from 'react';
+import { FaceMesh, Results } from '@mediapipe/face_mesh';
+
+import type { FaceAnalysisMetrics, FaceExpression } from '../types/analysis.types';
+
+const locateFile = (file: string) => `https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh/${file}`;
+
+const createFaceMesh = () => {
+  const faceMesh = new FaceMesh({ locateFile });
+  faceMesh.setOptions({
+    maxNumFaces: 1,
+    refineLandmarks: true,
+    minDetectionConfidence: 0.5,
+    minTrackingConfidence: 0.5,
+  });
+  return faceMesh;
+};
+
+const computeExpression = (results: Results): { label: FaceExpression; confidence: number } => {
+  const landmarks = results.multiFaceLandmarks?.[0];
+  if (!landmarks) {
+    return { label: 'neutral', confidence: 0 };
+  }
+
+  const mouthTop = landmarks[13];
+  const mouthBottom = landmarks[14];
+  const mouthHeight = Math.abs(mouthBottom.y - mouthTop.y);
+  const smileLeft = landmarks[61];
+  const smileRight = landmarks[291];
+  const smileCurve = smileRight.y - smileLeft.y;
+
+  if (mouthHeight > 0.07) {
+    return { label: 'surprised', confidence: Math.min(1, mouthHeight * 8) };
+  }
+
+  if (smileCurve < -0.005) {
+    return { label: 'happy', confidence: Math.min(1, Math.abs(smileCurve) * 50) };
+  }
+
+  return { label: 'neutral', confidence: 0.6 };
+};
+
+export const useMediaPipe = (params: { stream: MediaStream | null; sessionId: string; questionId?: string }) => {
+  const { stream, sessionId, questionId } = params;
+  const [metrics, setMetrics] = useState<FaceAnalysisMetrics | null>(null);
+  const animationRef = useRef<number>();
+
+  useEffect(() => {
+    if (!stream) {
+      setMetrics(null);
+      return undefined;
+    }
+
+    const videoElement = document.createElement('video');
+    videoElement.srcObject = stream;
+    videoElement.muted = true;
+    videoElement.playsInline = true;
+
+    let isMounted = true;
+    const faceMesh = createFaceMesh();
+
+    faceMesh.onResults((results) => {
+      if (!isMounted) return;
+      if (!results.multiFaceLandmarks?.length) {
+        setMetrics(null);
+        return;
+      }
+
+      const landmarks = results.multiFaceLandmarks[0];
+      const leftEye = landmarks[133];
+      const rightEye = landmarks[362];
+      const gazeX = ((leftEye.x + rightEye.x) / 2 - 0.5) * 2;
+      const gazeY = ((leftEye.y + rightEye.y) / 2 - 0.5) * 2;
+      const gazeDistance = Math.sqrt(gazeX ** 2 + gazeY ** 2);
+      const eyeContactScore = Math.max(0, 1 - gazeDistance);
+
+      const headPose = {
+        pitch: Number(((landmarks[10].z - landmarks[152].z) * 90).toFixed(2)),
+        yaw: Number(((landmarks[234].x - landmarks[454].x) * 90).toFixed(2)),
+        roll: Number(((landmarks[67].y - landmarks[297].y) * 90).toFixed(2)),
+      };
+
+      setMetrics({
+        sessionId,
+        questionId,
+        timestamp: Date.now(),
+        gaze: {
+          x: Number(gazeX.toFixed(3)),
+          y: Number(gazeY.toFixed(3)),
+          z: Number(((landmarks[1]?.z ?? 0) - 0.5).toFixed(3)),
+          confidence: results.multiFaceLandmarks.length > 0 ? 1 : 0,
+        },
+        eyeContactScore: Number(eyeContactScore.toFixed(3)),
+        expression: computeExpression(results),
+        headPose,
+      });
+    });
+
+    const analyze = async () => {
+      if (!isMounted) return;
+      try {
+        await faceMesh.send({ image: videoElement });
+      } catch {
+        // Ignore occasional MediaPipe errors
+      }
+      animationRef.current = requestAnimationFrame(analyze);
+    };
+
+    const start = async () => {
+      try {
+        await videoElement.play();
+        analyze();
+      } catch {
+        // autoplay might be blocked; ignore
+      }
+    };
+
+    start();
+
+    return () => {
+      isMounted = false;
+      if (animationRef.current) cancelAnimationFrame(animationRef.current);
+      faceMesh.close();
+      videoElement.pause();
+      videoElement.srcObject = null;
+    };
+  }, [questionId, sessionId, stream]);
+
+  return { metrics };
+};
+

--- a/frontend/src/features/interviews/hooks/useMediaStream.ts
+++ b/frontend/src/features/interviews/hooks/useMediaStream.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface UseMediaStreamOptions {
+  audio?: boolean;
+  video?: boolean;
+}
+
+const DEFAULT_OPTIONS: Required<UseMediaStreamOptions> = {
+  audio: true,
+  video: true,
+};
+
+export const useMediaStream = (options: UseMediaStreamOptions = DEFAULT_OPTIONS) => {
+  const [stream, setStream] = useState<MediaStream | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const optionsRef = useRef({ ...DEFAULT_OPTIONS, ...options });
+
+  const stopTracks = useCallback((targetStream: MediaStream | null) => {
+    targetStream?.getTracks().forEach((track) => track.stop());
+  }, []);
+
+  const requestStream = useCallback(async () => {
+    if (typeof navigator === 'undefined' || !navigator.mediaDevices) {
+      setError('브라우저에서 미디어 장치를 지원하지 않습니다.');
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const mediaStream = await navigator.mediaDevices.getUserMedia(optionsRef.current);
+      setStream((prev) => {
+        if (prev && prev.id !== mediaStream.id) {
+          stopTracks(prev);
+        }
+        return mediaStream;
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '미디어 장치 접근에 실패했습니다.');
+      setStream(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [stopTracks]);
+
+  useEffect(() => {
+    requestStream();
+    return () => {
+      stopTracks(stream);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const restart = useCallback(() => {
+    stopTracks(stream);
+    requestStream();
+  }, [requestStream, stopTracks, stream]);
+
+  return {
+    stream,
+    isLoading,
+    error,
+    restart,
+    stop: () => stopTracks(stream),
+  };
+};
+

--- a/frontend/src/features/interviews/hooks/useRealtimeAnalysis.ts
+++ b/frontend/src/features/interviews/hooks/useRealtimeAnalysis.ts
@@ -1,0 +1,51 @@
+import { useEffect, useRef, useState } from 'react';
+
+import type {
+  AudioAnalysisMetrics,
+  FaceAnalysisMetrics,
+  RealtimeAnalysisPayload,
+} from '../types/analysis.types';
+
+type UseRealtimeAnalysisOptions = {
+  sessionId?: string;
+  questionId?: string;
+  faceMetrics?: FaceAnalysisMetrics | null;
+  audioMetrics?: AudioAnalysisMetrics | null;
+  throttleMs?: number;
+  onEmit?: (payload: RealtimeAnalysisPayload) => void;
+};
+
+export const useRealtimeAnalysis = ({
+  sessionId,
+  questionId,
+  faceMetrics,
+  audioMetrics,
+  throttleMs = 1000,
+  onEmit,
+}: UseRealtimeAnalysisOptions) => {
+  const [latestPayload, setLatestPayload] = useState<RealtimeAnalysisPayload | null>(null);
+  const lastEmitRef = useRef(0);
+
+  useEffect(() => {
+    if (!sessionId) return;
+    if (!faceMetrics && !audioMetrics) return;
+
+    const now = Date.now();
+    if (now - lastEmitRef.current < throttleMs) return;
+
+    const payload: RealtimeAnalysisPayload = {
+      sessionId,
+      questionId,
+      timestamp: now,
+      face: faceMetrics ?? undefined,
+      audio: audioMetrics ?? undefined,
+    };
+
+    setLatestPayload(payload);
+    lastEmitRef.current = now;
+    onEmit?.(payload);
+  }, [audioMetrics, faceMetrics, onEmit, questionId, sessionId, throttleMs]);
+
+  return { latestPayload };
+};
+

--- a/frontend/src/features/interviews/services/interview.service.ts
+++ b/frontend/src/features/interviews/services/interview.service.ts
@@ -1,0 +1,30 @@
+import { apiClient } from '@/api/client';
+import { API_ENDPOINTS } from '@/constants/api';
+
+import type {
+  CreateInterviewSessionPayload,
+  InterviewEvaluation,
+  InterviewSession,
+} from '../types/interview.types';
+
+export const interviewService = {
+  async createSession(payload: CreateInterviewSessionPayload): Promise<InterviewSession> {
+    const response = await apiClient.post<InterviewSession>(API_ENDPOINTS.INTERVIEWS.SESSIONS, payload);
+    return response.data;
+  },
+
+  async getSession(sessionId: string): Promise<InterviewSession> {
+    const response = await apiClient.get<InterviewSession>(
+      API_ENDPOINTS.INTERVIEWS.SESSION_BY_ID(sessionId),
+    );
+    return response.data;
+  },
+
+  async getEvaluation(sessionId: string): Promise<InterviewEvaluation> {
+    const response = await apiClient.get<InterviewEvaluation>(
+      API_ENDPOINTS.INTERVIEWS.SESSION_EVALUATION(sessionId),
+    );
+    return response.data;
+  },
+};
+

--- a/frontend/src/features/interviews/services/socket.service.ts
+++ b/frontend/src/features/interviews/services/socket.service.ts
@@ -1,0 +1,69 @@
+import { io, type Socket } from 'socket.io-client';
+
+import type {
+  AudioStreamChunk,
+  ClientToServerEvents,
+  ServerToClientEvents,
+} from '../types/socket.types';
+
+const SOCKET_URL =
+  import.meta.env.VITE_SOCKET_URL ||
+  import.meta.env.VITE_API_BASE_URL ||
+  'http://localhost:3000';
+
+class InterviewSocketClient {
+  private socket?: Socket<ServerToClientEvents, ClientToServerEvents>;
+
+  connect(authToken?: string) {
+    if (this.socket) {
+      return this.socket;
+    }
+
+    this.socket = io(SOCKET_URL, {
+      path: '/ws/interviews',
+      transports: ['websocket'],
+      auth: authToken ? { token: authToken } : undefined,
+      autoConnect: true,
+    });
+
+    return this.socket;
+  }
+
+  disconnect() {
+    if (!this.socket) return;
+    this.socket.disconnect();
+    this.socket = undefined;
+  }
+
+  joinSession(sessionId: string) {
+    this.socket?.emit('interview:join', { sessionId });
+  }
+
+  leaveSession(sessionId: string) {
+    this.socket?.emit('interview:leave', { sessionId });
+  }
+
+  sendAudioChunk(payload: AudioStreamChunk) {
+    this.socket?.emit('interview:audio', payload);
+  }
+
+  sendRealtimeAnalysis(payload: Parameters<ClientToServerEvents['interview:analysis']>[0]) {
+    this.socket?.emit('interview:analysis', payload);
+  }
+
+  markAnswerComplete(payload: Parameters<ClientToServerEvents['interview:answer_complete']>[0]) {
+    this.socket?.emit('interview:answer_complete', payload);
+  }
+
+  endSession(payload: Parameters<ClientToServerEvents['interview:end']>[0]) {
+    this.socket?.emit('interview:end', payload);
+  }
+
+  on<E extends keyof ServerToClientEvents>(event: E, listener: ServerToClientEvents[E]) {
+    this.socket?.on(event, listener);
+    return () => this.socket?.off(event, listener);
+  }
+}
+
+export const interviewSocketClient = new InterviewSocketClient();
+

--- a/frontend/src/features/interviews/types/analysis.types.ts
+++ b/frontend/src/features/interviews/types/analysis.types.ts
@@ -1,0 +1,57 @@
+export interface GazeVector {
+  x: number;
+  y: number;
+  z: number;
+  confidence: number; // 0~1
+}
+
+export type FaceExpression =
+  | 'neutral'
+  | 'happy'
+  | 'sad'
+  | 'angry'
+  | 'surprised'
+  | 'fear'
+  | 'disgust'
+  | 'confused';
+
+export interface FaceExpressionScore {
+  label: FaceExpression;
+  confidence: number;
+}
+
+export interface HeadPose {
+  pitch: number;
+  yaw: number;
+  roll: number;
+}
+
+export interface FaceAnalysisMetrics {
+  sessionId: string;
+  questionId?: string;
+  timestamp: number; // epoch ms
+  gaze: GazeVector;
+  eyeContactScore: number; // 0~1
+  expression: FaceExpressionScore;
+  headPose: HeadPose;
+}
+
+export interface AudioAnalysisMetrics {
+  sessionId: string;
+  questionId?: string;
+  timestamp: number;
+  pitchHz: number;
+  energy: number;
+  speechRateWpm: number;
+  jitter: number;
+  pauses?: Array<{ start: number; end: number }>;
+}
+
+export interface RealtimeAnalysisPayload {
+  sessionId: string;
+  questionId?: string;
+  timestamp: number;
+  face?: FaceAnalysisMetrics;
+  audio?: AudioAnalysisMetrics;
+}
+

--- a/frontend/src/features/interviews/types/interview.types.ts
+++ b/frontend/src/features/interviews/types/interview.types.ts
@@ -1,0 +1,68 @@
+export type InterviewSessionStatus =
+  | 'pending'
+  | 'in_progress'
+  | 'paused'
+  | 'completed'
+  | 'cancelled';
+
+export type InterviewQuestionType = 'initial' | 'follow_up' | 'behavioral' | 'technical';
+
+export interface InterviewSession {
+  id: string;
+  userId?: string;
+  jobId?: string;
+  companyName: string;
+  jobTitle: string;
+  status: InterviewSessionStatus;
+  startedAt?: string;
+  completedAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface InterviewQuestion {
+  id: string;
+  sessionId: string;
+  order: number;
+  text: string;
+  type: InterviewQuestionType;
+  createdAt: string;
+}
+
+export interface InterviewAnswer {
+  id: string;
+  sessionId: string;
+  questionId: string;
+  transcript: string;
+  audioUrl?: string;
+  durationMs?: number;
+  createdAt: string;
+}
+
+export interface InterviewEvaluationMetric {
+  name: string;
+  score: number; // 0~100
+  comment?: string;
+}
+
+export interface InterviewEvaluation {
+  sessionId: string;
+  overallScore: number;
+  contentScore: number;
+  deliveryScore: number;
+  confidenceScore: number;
+  strengths: string[];
+  weaknesses: string[];
+  suggestions: string[];
+  metrics: InterviewEvaluationMetric[];
+  createdAt: string;
+}
+
+export interface CreateInterviewSessionPayload {
+  jobId?: string;
+  companyName: string;
+  jobTitle: string;
+  resumeId?: string;
+  notes?: string;
+}
+

--- a/frontend/src/features/interviews/types/socket.types.ts
+++ b/frontend/src/features/interviews/types/socket.types.ts
@@ -1,0 +1,55 @@
+import type { InterviewQuestion } from './interview.types';
+import type { RealtimeAnalysisPayload } from './analysis.types';
+
+export interface InterviewStartedEvent {
+  sessionId: string;
+  question: InterviewQuestion;
+}
+
+export interface InterviewQuestionEvent {
+  sessionId: string;
+  question: InterviewQuestion;
+}
+
+export interface InterviewFeedbackEvent {
+  sessionId: string;
+  metric: 'confidence' | 'delivery' | 'content' | 'engagement';
+  score: number;
+  message: string;
+  timestamp: number;
+}
+
+export interface InterviewCompletedEvent {
+  sessionId: string;
+  evaluationId?: string;
+}
+
+export interface InterviewErrorEvent {
+  code: string;
+  message: string;
+}
+
+export interface AudioStreamChunk {
+  sessionId: string;
+  chunk: ArrayBuffer;
+  timestamp: number;
+  durationMs: number;
+}
+
+export interface ClientToServerEvents {
+  'interview:join': (payload: { sessionId: string }) => void;
+  'interview:leave': (payload: { sessionId: string }) => void;
+  'interview:audio': (payload: AudioStreamChunk) => void;
+  'interview:analysis': (payload: RealtimeAnalysisPayload) => void;
+  'interview:answer_complete': (payload: { sessionId: string; questionId: string }) => void;
+  'interview:end': (payload: { sessionId: string }) => void;
+}
+
+export interface ServerToClientEvents {
+  'interview:started': (payload: InterviewStartedEvent) => void;
+  'interview:question': (payload: InterviewQuestionEvent) => void;
+  'interview:feedback': (payload: InterviewFeedbackEvent) => void;
+  'interview:completed': (payload: InterviewCompletedEvent) => void;
+  'interview:error': (payload: InterviewErrorEvent) => void;
+}
+

--- a/frontend/src/pages/interviews/InterviewResultPage.tsx
+++ b/frontend/src/pages/interviews/InterviewResultPage.tsx
@@ -1,0 +1,73 @@
+import { useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+
+import EvaluationChart from '@/features/interviews/components/EvaluationChart';
+import StrengthsWeaknesses from '@/features/interviews/components/StrengthsWeaknesses';
+import TimelineView from '@/features/interviews/components/TimelineView';
+
+const mockEvaluation = {
+  overallScore: 82,
+  contentScore: 78,
+  deliveryScore: 85,
+  confidenceScore: 80,
+  summary: '직무 이해도는 좋으나, 시선 처리와 말하기 속도를 조금 더 안정적으로 유지하면 좋겠습니다.',
+  strengths: ['구체적인 성과 언급으로 신뢰감을 줌', '목표 의식이 명확함'],
+  weaknesses: ['시선이 자주 화면을 벗어남', '답변 속도가 일정하지 않음'],
+  suggestions: ['카메라 렌즈를 주시하며 답변하기', '키 메시지를 정리한 뒤 말하기'],
+  metrics: [
+    { name: '논리 구성', score: 80 },
+    { name: '표정/시선', score: 70 },
+    { name: '목소리 안정성', score: 85 },
+  ],
+};
+
+const mockTimeline = [
+  {
+    id: '1',
+    question: '자기소개와 지원 동기를 말씀해주세요.',
+    score: 80,
+    feedback: '핵심 메시지는 명확하지만 속도가 빠르게 느껴집니다.',
+  },
+  {
+    id: '2',
+    question: '최근 해결한 어려운 문제를 설명해주세요.',
+    score: 85,
+    feedback: '구체적 수치가 인상적이었으며 구조적인 답변이었습니다.',
+  },
+  {
+    id: '3',
+    question: '우리 회사에서 이루고 싶은 목표는 무엇인가요?',
+    score: 78,
+    feedback: '기업 가치와 연결된 키워드가 조금 더 들어가면 좋겠습니다.',
+  },
+];
+
+const InterviewResultPage = () => {
+  const { sessionId } = useParams<{ sessionId: string }>();
+  const title = useMemo(() => sessionId ?? 'session', [sessionId]);
+
+  return (
+    <div className="mx-auto flex max-w-5xl flex-col gap-6 pb-16">
+      <header className="text-center">
+        <p className="text-xs font-semibold uppercase tracking-wide text-primary">Session #{title}</p>
+        <h1 className="mt-2 text-3xl font-bold text-black dark:text-white">AI 면접 평가 리포트</h1>
+        <p className="mt-3 text-sm text-gray-500 dark:text-gray-400">
+          면접 진행 동안 수집된 시선, 표정, 음성 데이터를 기반으로 분석한 결과입니다.
+        </p>
+      </header>
+
+      <EvaluationChart evaluation={mockEvaluation} />
+
+      <StrengthsWeaknesses
+        strengths={mockEvaluation.strengths}
+        weaknesses={mockEvaluation.weaknesses}
+        suggestions={mockEvaluation.suggestions}
+      />
+
+      <TimelineView items={mockTimeline} />
+    </div>
+  );
+};
+
+export default InterviewResultPage;
+

--- a/frontend/src/pages/interviews/InterviewSessionPage.tsx
+++ b/frontend/src/pages/interviews/InterviewSessionPage.tsx
@@ -1,0 +1,139 @@
+import { useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import QuestionDisplay from '@/features/interviews/components/QuestionDisplay';
+import SessionControls from '@/features/interviews/components/SessionControls';
+import VideoCapture from '@/features/interviews/components/VideoCapture';
+import { useMediaStream } from '@/features/interviews/hooks/useMediaStream';
+import { useMediaPipe } from '@/features/interviews/hooks/useMediaPipe';
+import { useAudioAnalysis } from '@/features/interviews/hooks/useAudioAnalysis';
+import { useRealtimeAnalysis } from '@/features/interviews/hooks/useRealtimeAnalysis';
+import RealtimeFeedback from '@/features/interviews/components/RealtimeFeedback';
+import { useInterviewSocket } from '@/features/interviews/hooks/useInterviewSocket';
+import { useInterviewSession } from '@/features/interviews/hooks/useInterviewSession';
+
+const InterviewSessionPage = () => {
+  const navigate = useNavigate();
+  const { sessionId } = useParams<{ sessionId: string }>();
+  const { stream, error } = useMediaStream();
+  const { session } = useInterviewSession(sessionId);
+  const {
+    currentQuestion: liveQuestion,
+    latestFeedback,
+    isConnected,
+    error: socketError,
+    sendRealtimeAnalysis,
+  } = useInterviewSocket({ sessionId });
+  const [status, setStatus] = useState<'idle' | 'running' | 'paused'>('idle');
+
+  const displaySessionId = useMemo(() => sessionId ?? session?.id ?? 'preview', [session?.id, sessionId]);
+  const fallbackQuestion = useMemo(
+    () => ({
+      id: 'mock-question-1',
+      order: 1,
+      text: '최근에 해결한 가장 어려운 문제와 이를 해결하기 위해 취한 접근 방식을 설명해주세요.',
+      type: 'initial' as const,
+    }),
+    [],
+  );
+
+  const activeQuestion = liveQuestion ?? fallbackQuestion;
+
+  const { metrics: faceMetrics } = useMediaPipe({
+    stream,
+    sessionId: displaySessionId,
+    questionId: activeQuestion.id,
+  });
+
+  const { metrics: audioMetrics } = useAudioAnalysis({
+    stream,
+    sessionId: displaySessionId,
+    questionId: activeQuestion.id,
+  });
+
+  useRealtimeAnalysis({
+    sessionId: displaySessionId,
+    questionId: activeQuestion.id,
+    faceMetrics,
+    audioMetrics,
+    onEmit: sendRealtimeAnalysis,
+  });
+
+  const handleStart = () => setStatus('running');
+  const handlePause = () => setStatus('paused');
+  const handleEnd = () => {
+    setStatus('idle');
+    navigate('/interviews/setup');
+  };
+
+  return (
+    <div className="flex flex-col gap-6 pb-10 lg:flex-row">
+      <section className="flex-1 rounded-2xl border border-stroke bg-black/90 p-4 shadow-lg dark:border-strokedark">
+        <div className="mb-4 flex items-center justify-between text-white/80">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-primary">Session</p>
+            <h2 className="text-xl font-semibold">세션 #{displaySessionId}</h2>
+          </div>
+          <button
+            type="button"
+            onClick={() => navigate('/interviews/setup')}
+            className="text-sm text-white/70 underline-offset-4 hover:underline"
+          >
+            종료
+          </button>
+        </div>
+        <VideoCapture
+          stream={stream}
+          placeholder={
+            <div className="p-4 text-center text-sm text-white/60">
+              {error ?? '카메라에 연결하는 중입니다.'}
+            </div>
+          }
+        />
+      </section>
+
+      <section className="flex w-full max-w-md flex-col gap-4 rounded-2xl border border-stroke bg-white p-6 shadow-sm dark:border-strokedark dark:bg-boxdark">
+        <header>
+          <p className="text-xs font-semibold uppercase tracking-wide text-primary">실시간 진행</p>
+          <h2 className="text-xl font-bold text-black dark:text-white">AI 면접 컨트롤</h2>
+        </header>
+
+        <QuestionDisplay question={activeQuestion} />
+
+        <div className="grid gap-3 md:grid-cols-2">
+          <div className="rounded-lg border border-stroke p-4 text-center dark:border-strokedark">
+            <p className="text-xs text-gray-500">타이머</p>
+            <p className="text-2xl font-bold text-black dark:text-white">00:00</p>
+          </div>
+          <div className="rounded-lg border border-stroke p-4 text-center dark:border-strokedark">
+            <p className="text-xs text-gray-500">질문 번호</p>
+            <p className="text-2xl font-bold text-black dark:text-white">1 / 6</p>
+          </div>
+        </div>
+
+        <RealtimeFeedback faceMetrics={faceMetrics} audioMetrics={audioMetrics} />
+
+        <div className="rounded-xl border border-stroke p-4 text-sm dark:border-strokedark">
+          <div className="flex items-center justify-between">
+            <span className="font-semibold text-gray-600 dark:text-gray-300">연결 상태</span>
+            <span className={isConnected ? 'text-success' : 'text-gray-400'}>
+              {isConnected ? '실시간 연결됨' : '대기 중'}
+            </span>
+          </div>
+          {socketError && <p className="mt-2 text-xs text-danger">{socketError}</p>}
+          {latestFeedback && (
+            <div className="mt-3 rounded-lg bg-primary/5 p-3 text-xs text-gray-600 dark:text-gray-300">
+              <p className="font-semibold text-primary">AI 피드백</p>
+              <p className="mt-1 text-sm text-black dark:text-white">{latestFeedback.message}</p>
+            </div>
+          )}
+        </div>
+
+        <SessionControls status={status} onStart={handleStart} onPause={handlePause} onEnd={handleEnd} />
+      </section>
+    </div>
+  );
+};
+
+export default InterviewSessionPage;
+

--- a/frontend/src/pages/interviews/InterviewSetupPage.tsx
+++ b/frontend/src/pages/interviews/InterviewSetupPage.tsx
@@ -1,0 +1,106 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const InterviewSetupPage = () => {
+  const navigate = useNavigate();
+  const [formData, setFormData] = useState({
+    companyName: '',
+    jobTitle: '',
+    resumeId: '',
+    notes: '',
+  });
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = event.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleStart = () => {
+    // TODO: 실제 세션 생성 API 연동
+    navigate('/interviews/session/preview');
+  };
+
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col gap-6 pb-16">
+      <header className="text-center">
+        <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-primary">
+          Interview Simulator
+        </p>
+        <h1 className="text-3xl font-bold text-black dark:text-white">AI 모의 면접 준비</h1>
+        <p className="mt-3 text-sm text-gray-500 dark:text-gray-400">
+          기업 정보와 직무를 선택하면 AI가 맞춤형 면접 질문을 생성합니다.
+        </p>
+      </header>
+
+      <section className="rounded-2xl border border-stroke bg-white p-6 shadow-sm dark:border-strokedark dark:bg-boxdark">
+        <div className="mb-6 flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 font-bold text-primary">
+            1
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold text-black dark:text-white">기업 및 직무 설정</h2>
+            <p className="text-sm text-gray-500 dark:text-gray-400">모의 면접 대상 정보를 입력하세요.</p>
+          </div>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-semibold text-gray-600 dark:text-gray-300">기업명</label>
+            <input
+              type="text"
+              name="companyName"
+              value={formData.companyName}
+              onChange={handleChange}
+              placeholder="예) 네이버"
+              className="rounded-lg border border-stroke bg-transparent px-4 py-3 text-sm outline-none transition focus:border-primary dark:border-form-strokedark dark:bg-form-input"
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-semibold text-gray-600 dark:text-gray-300">직무</label>
+            <input
+              type="text"
+              name="jobTitle"
+              value={formData.jobTitle}
+              onChange={handleChange}
+              placeholder="예) 프론트엔드 개발자"
+              className="rounded-lg border border-stroke bg-transparent px-4 py-3 text-sm outline-none transition focus:border-primary dark:border-form-strokedark dark:bg-form-input"
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-2xl border border-stroke bg-white p-6 shadow-sm dark:border-strokedark dark:bg-boxdark">
+        <div className="mb-6 flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 font-bold text-primary">
+            2
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold text-black dark:text-white">자기소개서 / 메모</h2>
+            <p className="text-sm text-gray-500 dark:text-gray-400">면접 시 참고할 내용을 추가하세요.</p>
+          </div>
+        </div>
+
+        <textarea
+          name="notes"
+          rows={6}
+          value={formData.notes}
+          onChange={handleChange}
+          placeholder="강조하고 싶은 경험, 질문받고 싶은 주제 등을 적어주세요."
+          className="w-full rounded-lg border border-stroke bg-transparent px-4 py-3 text-sm outline-none transition focus:border-primary dark:border-form-strokedark dark:bg-form-input"
+        />
+      </section>
+
+      <div className="sticky bottom-6 flex items-center justify-center">
+        <button
+          onClick={handleStart}
+          className="inline-flex items-center gap-2 rounded-full bg-primary px-10 py-4 text-lg font-semibold text-white shadow-lg transition hover:-translate-y-0.5 hover:bg-primary/90"
+        >
+          모의 면접 시작하기
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default InterviewSetupPage;
+

--- a/frontend/src/router/routes.tsx
+++ b/frontend/src/router/routes.tsx
@@ -3,6 +3,9 @@ import DefaultLayout from "../components/layout/DefaultLayout";
 import MainDashboardPage from "../features/dashboard/MainDashboardPage";
 import ResumeAnalysisPage from "../features/analysis/ResumeAnalysisPage";
 import AnalysisResultPage from "../features/analysis/AnalysisResultPage";
+import InterviewSetupPage from "../pages/interviews/InterviewSetupPage";
+import InterviewSessionPage from "../pages/interviews/InterviewSessionPage";
+import InterviewResultPage from "../pages/interviews/InterviewResultPage";
 // ... 다른 import들
 
 const router = createBrowserRouter([
@@ -27,6 +30,30 @@ const router = createBrowserRouter([
     element: (
       <DefaultLayout>
         <AnalysisResultPage />
+      </DefaultLayout>
+    ),
+  },
+  {
+    path: "/interviews/setup",
+    element: (
+      <DefaultLayout>
+        <InterviewSetupPage />
+      </DefaultLayout>
+    ),
+  },
+  {
+    path: "/interviews/session/:sessionId",
+    element: (
+      <DefaultLayout>
+        <InterviewSessionPage />
+      </DefaultLayout>
+    ),
+  },
+  {
+    path: "/interviews/result/:sessionId",
+    element: (
+      <DefaultLayout>
+        <InterviewResultPage />
       </DefaultLayout>
     ),
   },

--- a/frontend/src/types/pitchfinder.d.ts
+++ b/frontend/src/types/pitchfinder.d.ts
@@ -1,0 +1,10 @@
+declare module 'pitchfinder' {
+  interface DetectorConfig {
+    sampleRate?: number;
+  }
+
+  type Detector = (buffer: Float32Array, sampleRate?: number) => number | null;
+
+  export function YIN(config?: DetectorConfig): Detector;
+}
+


### PR DESCRIPTION
#### 1. 폴더 구조

```
frontend/src/
├── pages/interviews/
│   ├── InterviewSetupPage.tsx      # 기업/직무 입력 및 데모 세션 시작
│   ├── InterviewSessionPage.tsx    # 실시간 면접 진행 화면
│   └── InterviewResultPage.tsx     # 모의 평가 리포트
└── features/interviews/
    ├── components/                 # 재사용 가능한 UI 블록
    │   ├── VideoCapture.tsx        # 카메라 스트림 표시
    │   ├── AudioIndicator.tsx      # 마이크 레벨 게이지
    │   ├── QuestionDisplay.tsx     # 질문 카드
    │   ├── SessionControls.tsx     # 시작/일시정지/종료 버튼
    │   ├── RealtimeFeedback.tsx    # 실시간 피드백 래퍼
    │   ├── GazeIndicator.tsx       # 시선 집중도
    │   ├── ExpressionIndicator.tsx # 표정/헤드포즈
    │   ├── AudioFeedback.tsx       # 피치·에너지·WPM·Jitter
    │   ├── EvaluationChart.tsx     # 종합 점수 차트
    │   ├── TimelineView.tsx        # 질문별 타임라인
    │   └── StrengthsWeaknesses.tsx # 강점/약점/제안 정리
    ├── hooks/
    │   ├── useMediaStream.ts       # getUserMedia 래퍼
    │   ├── useMediaPipe.ts         # MediaPipe FaceMesh 분석
    │   ├── useAudioAnalysis.ts     # Web Audio API + pitchfinder
    │   ├── useRealtimeAnalysis.ts  # 분석 데이터 패키징/전송
    │   ├── useInterviewSocket.ts   # Socket.IO 연결/이벤트
    │   └── useInterviewSession.ts  # REST 세션 상태 관리
    ├── services/
    │   ├── interview.service.ts    # REST (세션 생성/조회/평가)
    │   └── socket.service.ts       # Socket.IO 클라이언트
    └── types/
        ├── interview.types.ts      # 세션/질문/평가 모델
        ├── analysis.types.ts       # 얼굴·음성 분석 페이로드
        └── socket.types.ts         # WS 이벤트 정의
```

#### 2. 사용 라이브러리

- React 19 + Vite + Tailwind (UI)
- `socket.io-client` (WebSocket)
- `@mediapipe/face_mesh`, `@tensorflow-models/face-landmarks-detection`, `kalidokit` (시선·표정 추정)
- Web Audio API + `pitchfinder` (피치/에너지)
- React Router / Axios 등 공통 스택

#### 3. 구현 기능
<img width="1080" height="784" alt="image" src="https://github.com/user-attachments/assets/15c0b814-89d4-45bd-8e18-bc3fb3fe0483" />

<img width="1490" height="840" alt="image" src="https://github.com/user-attachments/assets/d1d9089f-d0a9-46f5-99d4-994e6b733be9" />

<img width="451" height="850" alt="image" src="https://github.com/user-attachments/assets/b3a86c8e-9bb6-4e26-bb3f-6a00263a9c80" />



- **라우팅**: `/interviews/setup`, `/interviews/session/:sessionId`, `/interviews/result/:sessionId` (DefaultLayout 사용, 세션 페이지는 사이드바 숨김)
- **카메라/마이크 제어**: `useMediaStream` → `VideoCapture`, `AudioIndicator`
- **실시간 분석(프론트)**: MediaPipe FaceMesh + Web Audio API로 시선/표정/헤드포즈/피치/에너지를 측정해 UI에 표시
- **WebSocket 뼈대**: `socket.service.ts`와 `useInterviewSocket`이 질문/피드백 이벤트를 구독하고, `useRealtimeAnalysis`가 실시간 데이터를 emit하도록 설계
- **면접 결과 UI**: 차트/타임라인/강점·약점 카드로 Mock 데이터를 시각화
- **CTA 연동**: 분석 결과 페이지 및 사이드바에서 면접 페이지로 자연스럽게 연결

> 설치 시 `@mediapipe/face_mesh`, `@tensorflow-models/face-landmarks-detection`, `kalidokit`, `pitchfinder`, `socket.io-client`를 함께 설치해야 하며, npm 레지스트리에 존재하는 버전으로 지정해야 합니다. (`@tensorflow-models/face-landmarks-detection`은 현재 `^1.0.4`를 권장)

#### 도커 실행에서 알아서 처리 따로 `npm install` 필요 X
---

### 2. Nest.js 기반 백엔드 계획

#### 2-1. API & 소켓 책임

| 역할                 | 상세                                                                                                                                                                                                   |
| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| 세션 REST API        | `POST /interviews/sessions` (세션 생성), `GET /interviews/sessions/:id`, `GET /interviews/sessions/:id/evaluation`                                                                                     |
| Socket.IO 게이트웨이 | 네임스페이스 `/ws/interviews`에서 <br/>`interview:question`, `interview:feedback`, `interview:completed` 이벤트 송신 및 <br/>`interview:audio`, `interview:analysis`, `interview:answer_complete` 수신 |
| 인증                 | Front → Socket 연결 시 토큰 전달 후 게이트웨이에서 검증 (예: JWT)                                                                                                                                      |
| 데이터 저장          | PostgreSQL/Prisma(TypeORM)로 세션, 질문, 답변, 분석 프레임, 평가 결과 저장                                                                                                                             |

> **LLM/STT/TTS도 Nest.js 서비스에서 처리**
>
> - OpenAI SDK(또는 LangChain.js)를 Nest Provider로 등록하여 질문/피드백 생성
> - Whisper API로 STT 호출 후 답변 텍스트 저장
> - 필요 시 에이전트 패턴도 Node 진영에서 구현 가능

#### 2-2. 데이터 흐름

1. 프론트: 카메라/마이크 스트림 수집 → 간단한 로컬 분석 → `RealtimeAnalysisPayload` emit
2. Nest 소켓 게이트웨이: payload 수신 → STT/LLM 호출에 참고 → 질문/피드백 생성 후 프론트로 push
3. Nest REST API: 세션 생성·조회·평가 저장, 클라이언트 결과 페이지에서 조회
4. 프론트: 서버에서 온 질문/피드백/평가 데이터를 UI에 반영

#### 2-3. 백엔드 Checklist

1. **엔티티/스키마**: `interview_sessions`, `interview_questions`, `interview_answers`, `analysis_frames`, `interview_evaluations`
2. **Auth & Session Guard**: JWT/쿠키 기반 인증 후 소켓 연결 시 토큰 검증
3. **파일/스트림 처리**: 오디오 청크 포맷 정의, Whisper API 호출 파이프라인 마련
4. **큐/캐시**: Redis로 실시간 분석 값 캐싱 및 세션 상태 관리
5. **모니터링**: WebSocket 연결 수, LLM/Whisper 호출 지연, 에러 로깅

---

### 고려사항
- 백엔드에 festapi 확장을 고려해볼 수 있음


파이썬을 사용하지 않고 TS기반으로 구현한 이유
- 초기 프로토타입에서 백엔드 의존 없이 기능 검증 가능
- MediaPipe/TF.js 패키지가 웹에 최적화되어 빠른 구현/테스트가 가능
- 서버가 준비되지 않아도 UX 흐름을 확정할 수 있음
