### PR TITLE
fix(#30): PDF 파서 문제 해결

### DIFF
--- a/backend/src/features/analysis/analysis.service.ts
+++ b/backend/src/features/analysis/analysis.service.ts
@@ -7,8 +7,9 @@ import { ConfigService } from '@nestjs/config';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { z } from 'zod';
 
+// pdf-parse 2.x: PDFParse 클래스 + getText() (구버전 pdfParse(buffer) 미지원)
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const pdfParse = require('pdf-parse');
+const { PDFParse } = require('pdf-parse');
 
 @Injectable()
 export class AnalysisService {
@@ -52,11 +53,14 @@ export class AnalysisService {
    * PDF 텍스트 추출
    */
   async extractTextFromPdf(buffer: Buffer): Promise<string> {
+    const parser = new PDFParse({ data: buffer });
     try {
-      const data = await pdfParse(buffer);
-      return data.text;
+      const result = await parser.getText();
+      return result.text;
     } catch {
       throw new InternalServerErrorException('PDF 텍스트 추출 실패');
+    } finally {
+      await parser.destroy();
     }
   }
 


### PR DESCRIPTION
## 1. PDF 파싱 실패
원인: package.json에는 pdf-parse 2.x가 있는데, 코드는 1.x 때 쓰던 방식(pdfParse(buffer) 한 번에 호출)이었음.
## 2.x는 PDFParse 클래스로 열고 getText()로 텍스트를 가져와야 함.
그래서 파싱 단계에서 예외가 나고, catch에서 PDF 파싱 실패로만 보였던 것.
조치: analysis.service.ts에서 2.x API로 맞춤.